### PR TITLE
chore: allow symfony/console ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/console": "^6.3",
+        "symfony/console": "^6.3 || ^7.0",
         "symfony/finder": "*",
         "symfony/event-dispatcher": "*",
         "symfony/yaml": "*",


### PR DESCRIPTION
## Summary
- Widens `symfony/console` constraint from `^6.3` to `^6.3 || ^7.0` so the ChMS app can upgrade `symfony/console` to `^7.4` without keeping this constraint as the blocker.

## Test plan
- [ ] In `churchcommunitybuilder` ChMS, point the dspec require at this branch's SHA and run `composer require --dev symfony/console:^7.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)